### PR TITLE
jobs.resume now used only if --resumable flag is passed

### DIFF
--- a/jobrun.pl
+++ b/jobrun.pl
@@ -85,7 +85,7 @@ usage(0) if $help;
 # assumed filename is name.extension
 my $resumableFile = (split(/[.]/,$jobFile))[0] . '.resume';
 
-if ( -f $resumableFile ) { $jobFile = $resumableFile; };
+if ( -f $resumableFile and $resumable ) { $jobFile = $resumableFile; };
 
 -r $configFile || croak "could not read $configFile - $!\n";
 -r $jobFile || croak "could not read $jobFile - $!\n";


### PR DESCRIPTION
Previously the jobs.resume file would always be used if present, which was incorrect behavior