### PR TITLE
Dev/reload config

### DIFF
--- a/jobrun.conf
+++ b/jobrun.conf
@@ -3,7 +3,7 @@
 debug:0
 verbose:0
 resumable:0
-maxjobs:4
+maxjobs:2
 iteration-seconds:2
 timestamp-format:%Y-%m-%d %H:%M:%S
 logdir:./logs

--- a/jobs.conf
+++ b/jobs.conf
@@ -1,5 +1,5 @@
 # comments and blank lines ignored
-job-1:./test-job.sh job-1 6
+job-1:./test-job.sh job-1 600
 job-2:./test-job.sh job-2 10
 job-3:./test-job.sh job-3 7
 job-4:./test-job.sh job-4 10


### PR DESCRIPTION
Changes allow using `jobrun-pl --reload-config` to cause the main `jobrun.pl` process to reload the configuration.
This is most useful for controlling how many jobs are allowed to run simultaneously