### PR TITLE
fixed a bug in the job status table - one too many commas

### DIFF
--- a/lib/Jobrun.pm
+++ b/lib/Jobrun.pm
@@ -288,16 +288,15 @@ sub new {
 	my $retval = bless \%args, $class;
 
 	$retval->{insert}(
-		$retval,
-		$retval->{JOBNAME},    #job name
-		$$,                    #pid
+		$retval
+		, $retval->{JOBNAME}   #job name
+		, $$                   #pid
 		, 'running'            #status
 		, 'NA'                 #exit code
 		, ''                   #start time
 		, ''                   #end time
 		, ''                   #elapsed time
-		, $retval->{CMD},      #command
-
+		, $retval->{CMD}       #command
 	);
 	return $retval;
 }


### PR DESCRIPTION
There were one too many commas where the job status table was updated